### PR TITLE
Add admin checks to product and category APIs

### DIFF
--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { getUserIdFromRequest, isAdmin } from '@/lib/auth/auth-utils';
 
 interface Params {
   params: {
@@ -41,6 +42,22 @@ export async function GET(req: NextRequest, { params }: Params) {
 // PUT /api/categories/[id] - Update a category
 export async function PUT(req: NextRequest, { params }: Params) {
   try {
+    const userId = await getUserIdFromRequest(req);
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Unauthorized. Please log in.' },
+        { status: 401 }
+      );
+    }
+
+    if (!(await isAdmin(userId))) {
+      return NextResponse.json(
+        { error: 'Forbidden. Admins only.' },
+        { status: 403 }
+      );
+    }
+
     const { id } = params;
     const { name, description, showOnHomepage } = await req.json();
     
@@ -79,6 +96,22 @@ export async function PUT(req: NextRequest, { params }: Params) {
 // DELETE /api/categories/[id] - Delete a category
 export async function DELETE(req: NextRequest, { params }: Params) {
   try {
+    const userId = await getUserIdFromRequest(req);
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Unauthorized. Please log in.' },
+        { status: 401 }
+      );
+    }
+
+    if (!(await isAdmin(userId))) {
+      return NextResponse.json(
+        { error: 'Forbidden. Admins only.' },
+        { status: 403 }
+      );
+    }
+
     const { id } = params;
     
     // Check if category exists

--- a/src/app/api/categories/[id]/toggle-homepage/route.ts
+++ b/src/app/api/categories/[id]/toggle-homepage/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { getUserIdFromRequest, isAdmin } from '@/lib/auth/auth-utils';
 
 interface Params {
   params: {
@@ -10,6 +11,22 @@ interface Params {
 // PATCH /api/categories/[id]/toggle-homepage - Toggle homepage visibility
 export async function PATCH(req: NextRequest, { params }: Params) {
   try {
+    const userId = await getUserIdFromRequest(req);
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Unauthorized. Please log in.' },
+        { status: 401 }
+      );
+    }
+
+    if (!(await isAdmin(userId))) {
+      return NextResponse.json(
+        { error: 'Forbidden. Admins only.' },
+        { status: 403 }
+      );
+    }
+
     const { id } = params;
     
     // Find the category first

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { getUserIdFromRequest, isAdmin } from '@/lib/auth/auth-utils';
 
 // GET /api/categories - Get all categories
 export async function GET(req: NextRequest) {
@@ -29,6 +30,22 @@ export async function GET(req: NextRequest) {
 // POST /api/categories - Create a new category
 export async function POST(req: NextRequest) {
   try {
+    const userId = await getUserIdFromRequest(req);
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Unauthorized. Please log in.' },
+        { status: 401 }
+      );
+    }
+
+    if (!(await isAdmin(userId))) {
+      return NextResponse.json(
+        { error: 'Forbidden. Admins only.' },
+        { status: 403 }
+      );
+    }
+
     const { name, description, showOnHomepage } = await req.json();
 
     // Validate input
@@ -60,6 +77,22 @@ export async function POST(req: NextRequest) {
 // PATCH method is used for bulk operations
 export async function PATCH(req: NextRequest) {
   try {
+    const userId = await getUserIdFromRequest(req);
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Unauthorized. Please log in.' },
+        { status: 401 }
+      );
+    }
+
+    if (!(await isAdmin(userId))) {
+      return NextResponse.json(
+        { error: 'Forbidden. Admins only.' },
+        { status: 403 }
+      );
+    }
+
     const { categories } = await req.json();
     
     if (!categories || !Array.isArray(categories)) {

--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { getUserIdFromRequest, isAdmin } from '@/lib/auth/auth-utils';
 
 interface Params {
   params: {
@@ -47,6 +48,22 @@ export async function GET(req: NextRequest, { params }: Params) {
 // PUT /api/products/[id] - Update a product
 export async function PUT(req: NextRequest, { params }: Params) {
   try {
+    const userId = await getUserIdFromRequest(req);
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Unauthorized. Please log in.' },
+        { status: 401 }
+      );
+    }
+
+    if (!(await isAdmin(userId))) {
+      return NextResponse.json(
+        { error: 'Forbidden. Admins only.' },
+        { status: 403 }
+      );
+    }
+
     const { id } = params;
     const data = await req.json();
     
@@ -103,6 +120,22 @@ export async function PUT(req: NextRequest, { params }: Params) {
 // DELETE /api/products/[id] - Delete a product
 export async function DELETE(req: NextRequest, { params }: Params) {
   try {
+    const userId = await getUserIdFromRequest(req);
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Unauthorized. Please log in.' },
+        { status: 401 }
+      );
+    }
+
+    if (!(await isAdmin(userId))) {
+      return NextResponse.json(
+        { error: 'Forbidden. Admins only.' },
+        { status: 403 }
+      );
+    }
+
     const { id } = params;
     
     // Check if product exists

--- a/src/app/api/products/[id]/toggle-featured/route.ts
+++ b/src/app/api/products/[id]/toggle-featured/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { getUserIdFromRequest, isAdmin } from '@/lib/auth/auth-utils';
 
 interface Params {
   params: {
@@ -10,6 +11,22 @@ interface Params {
 // PATCH /api/products/[id]/toggle-featured - Toggle featured status
 export async function PATCH(req: NextRequest, { params }: Params) {
   try {
+    const userId = await getUserIdFromRequest(req);
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Unauthorized. Please log in.' },
+        { status: 401 }
+      );
+    }
+
+    if (!(await isAdmin(userId))) {
+      return NextResponse.json(
+        { error: 'Forbidden. Admins only.' },
+        { status: 403 }
+      );
+    }
+
     const { id } = params;
     
     // Find the product first

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { getUserIdFromRequest, isAdmin } from '@/lib/auth/auth-utils';
 
 // GET /api/products - Get all products with filtering and pagination
 export async function GET(req: NextRequest) {
@@ -79,6 +80,22 @@ export async function GET(req: NextRequest) {
 // POST /api/products - Create a new product
 export async function POST(req: NextRequest) {
   try {
+    const userId = await getUserIdFromRequest(req);
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Unauthorized. Please log in.' },
+        { status: 401 }
+      );
+    }
+
+    if (!(await isAdmin(userId))) {
+      return NextResponse.json(
+        { error: 'Forbidden. Admins only.' },
+        { status: 403 }
+      );
+    }
+
     const data = await req.json();
     
     // Validate required fields


### PR DESCRIPTION
## Summary
- ensure modifying products requires admin privileges
- ensure modifying categories requires admin privileges

## Testing
- `npm run lint` *(fails: next not found)*