### PR TITLE
Implement basic events API

### DIFF
--- a/src/app/api/events/[id]/cancel/route.ts
+++ b/src/app/api/events/[id]/cancel/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getUserIdFromRequest } from '@/lib/auth/auth-utils';
+
+interface Params {
+  params: {
+    id: string;
+  };
+}
+
+// POST /api/events/[id]/cancel - cancel registration
+export async function POST(req: NextRequest, { params }: Params) {
+  try {
+    const userId = await getUserIdFromRequest(req);
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = params;
+    const registration = await prisma.eventRegistration.findUnique({ where: { eventId_userId: { eventId: id, userId } } });
+    if (!registration) {
+      return NextResponse.json({ error: 'Registration not found' }, { status: 404 });
+    }
+
+    const updated = await prisma.eventRegistration.update({
+      where: { id: registration.id },
+      data: { paymentStatus: 'cancelled' }
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error(`Error cancelling registration for event ${params.id}:`, error);
+    return NextResponse.json({ error: 'Failed to cancel registration' }, { status: 500 });
+  }
+}

--- a/src/app/api/events/[id]/register/route.ts
+++ b/src/app/api/events/[id]/register/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getUserIdFromRequest } from '@/lib/auth/auth-utils';
+
+interface Params {
+  params: {
+    id: string;
+  };
+}
+
+// POST /api/events/[id]/register - user register for event
+export async function POST(req: NextRequest, { params }: Params) {
+  try {
+    const userId = await getUserIdFromRequest(req);
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = params;
+    const event = await prisma.event.findUnique({ where: { id } });
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 });
+    }
+
+    if (event.maxParticipants && event.maxParticipants > 0) {
+      const count = await prisma.eventRegistration.count({ where: { eventId: id, paymentStatus: { not: 'cancelled' } } });
+      if (count >= event.maxParticipants) {
+        return NextResponse.json({ error: 'Event is full' }, { status: 400 });
+      }
+    }
+
+    const existing = await prisma.eventRegistration.findUnique({ where: { eventId_userId: { eventId: id, userId } } });
+    if (existing) {
+      return NextResponse.json({ error: 'Already registered' }, { status: 400 });
+    }
+
+    const additionalInfo = (await req.json()).additionalInfo || null;
+
+    const reg = await prisma.eventRegistration.create({
+      data: {
+        eventId: id,
+        userId,
+        additionalInfo,
+        paymentStatus: event.fee && event.fee.toNumber() > 0 ? 'unpaid' : 'paid'
+      }
+    });
+
+    return NextResponse.json(reg, { status: 201 });
+  } catch (error) {
+    console.error(`Error registering for event ${params.id}:`, error);
+    return NextResponse.json({ error: 'Failed to register' }, { status: 500 });
+  }
+}

--- a/src/app/api/events/[id]/registrations/route.ts
+++ b/src/app/api/events/[id]/registrations/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getUserIdFromRequest, isAdmin } from '@/lib/auth/auth-utils';
+
+interface Params {
+  params: {
+    id: string;
+  };
+}
+
+// GET /api/events/[id]/registrations - list event registrations (admin only)
+export async function GET(req: NextRequest, { params }: Params) {
+  try {
+    const userId = await getUserIdFromRequest(req);
+    if (!userId || !(await isAdmin(userId))) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = params;
+    const registrations = await prisma.eventRegistration.findMany({
+      where: { eventId: id },
+      include: { user: { select: { id: true, username: true, email: true } } },
+      orderBy: { registerTime: 'desc' }
+    });
+
+    return NextResponse.json(registrations);
+  } catch (error) {
+    console.error(`Error fetching registrations for event ${params.id}:`, error);
+    return NextResponse.json({ error: 'Failed to fetch registrations' }, { status: 500 });
+  }
+}

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getUserIdFromRequest, isAdmin } from '@/lib/auth/auth-utils';
+
+interface Params {
+  params: {
+    id: string;
+  };
+}
+
+// GET /api/events/[id] - get event details
+export async function GET(req: NextRequest, { params }: Params) {
+  try {
+    const { id } = params;
+    const event = await prisma.event.findUnique({ where: { id } });
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 });
+    }
+    return NextResponse.json(event);
+  } catch (error) {
+    console.error(`Error fetching event ${params.id}:`, error);
+    return NextResponse.json({ error: 'Failed to fetch event' }, { status: 500 });
+  }
+}
+
+// PUT /api/events/[id] - update event (admin only)
+export async function PUT(req: NextRequest, { params }: Params) {
+  try {
+    const userId = await getUserIdFromRequest(req);
+    if (!userId || !(await isAdmin(userId))) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = params;
+    const data = await req.json();
+
+    const existing = await prisma.event.findUnique({ where: { id } });
+    if (!existing) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 });
+    }
+
+    const event = await prisma.event.update({ where: { id }, data });
+    return NextResponse.json(event);
+  } catch (error) {
+    console.error(`Error updating event ${params.id}:`, error);
+    return NextResponse.json({ error: 'Failed to update event' }, { status: 500 });
+  }
+}

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getUserIdFromRequest, isAdmin } from '@/lib/auth/auth-utils';
+
+// GET /api/events - list events with optional status filter
+export async function GET(req: NextRequest) {
+  try {
+    const url = new URL(req.url);
+    const status = url.searchParams.get('status');
+    const page = parseInt(url.searchParams.get('page') || '1');
+    const limit = parseInt(url.searchParams.get('limit') || '10');
+
+    const skip = (page - 1) * limit;
+
+    const whereClause: any = {};
+    if (status) {
+      whereClause.status = status;
+    }
+
+    const [events, totalCount] = await Promise.all([
+      prisma.event.findMany({
+        where: whereClause,
+        orderBy: { startTime: 'desc' },
+        skip,
+        take: limit
+      }),
+      prisma.event.count({ where: whereClause })
+    ]);
+
+    const totalPages = Math.ceil(totalCount / limit);
+
+    return NextResponse.json({
+      events,
+      pagination: {
+        page,
+        limit,
+        totalCount,
+        totalPages,
+        hasMore: page < totalPages
+      }
+    });
+  } catch (error) {
+    console.error('Error fetching events:', error);
+    return NextResponse.json({ error: 'Failed to fetch events' }, { status: 500 });
+  }
+}
+
+// POST /api/events - create a new event (admin only)
+export async function POST(req: NextRequest) {
+  try {
+    const userId = await getUserIdFromRequest(req);
+    if (!userId || !(await isAdmin(userId))) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const data = await req.json();
+    const requiredFields = ['title', 'description', 'type', 'startTime', 'endTime', 'location'];
+    if (!requiredFields.every(f => data[f])) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const event = await prisma.event.create({ data });
+    return NextResponse.json(event, { status: 201 });
+  } catch (error) {
+    console.error('Error creating event:', error);
+    return NextResponse.json({ error: 'Failed to create event' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add new API routes under `api/events` for managing and registering events

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next')*
- `npx next lint` *(fails: request to https://registry.npmjs.org/next failed)*